### PR TITLE
Fix commons-lang3 compile issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,13 @@
 					<targetVersion>ES5</targetVersion>
 					<candiesJsOut>target/candies</candiesJsOut>
 				</configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                        <version>3.7</version>
+                    </dependency>
+                </dependencies>
 				<executions>
 					<execution>
 						<id>generate-js</id>


### PR DESCRIPTION
When doing a fresh clone of the examples
project and executing `mvn generate-sources` I got
the following error:
```
Failed to execute goal org.jsweet:jsweet-maven-plugin:2.2.0-SNAPSHOT:jsweet (generate-js) on project jsweet-quickstart: Execution generate-js of goal org.jsweet:jsweet-maven-plugin:2.2.0-SNAPSHOT:jsweet failed: An API incompatibility was encountered while executing org.jsweet:jsweet-maven-plugin:2.2.0-SNAPSHOT:jsweet: java.lang.NoSuchMethodError: org.apache.commons.lang3.ArrayUtils.insert(I[Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
```

This appears to be because some dependency is bringing in
commons-lang3 version 3.5 which doesn't have the necessary
ArrayUtils.insert method used in the transpiler class
`ProcessUtil` referenced here: https://github.com/cincheo/jsweet/blob/3de2c5ef046e328653df38f1db83aaafe91c762f/transpiler/src/main/java/org/jsweet/transpiler/util/ProcessUtil.java#L208

Updating the jsweet-maven-plugin to have the specific
dependency for commons-lang3 version 3.7 fixes the issue.