### PR TITLE
Update RayTracer.java

### DIFF
--- a/src/main/java/org/jsweet/examples/raytracer/RayTracer.java
+++ b/src/main/java/org/jsweet/examples/raytracer/RayTracer.java
@@ -359,7 +359,7 @@ class RayTracer {
 				Color color = this.traceRay(new Ray(scene.camera.pos, getPoint.apply(x, y, scene.camera)), scene, 0);
 				Color c = Color.toDrawingColor(color);
 				ctx.fillStyle = union("rgb(" + new String(c.r) + ", " + new String(c.g) + ", " + new String(c.b) + ")");
-				ctx.fillRect(x, y, x + 1, y + 1);
+				ctx.fillRect(x, y, 1, 1);
 			}
 		}
 	}


### PR DESCRIPTION
`fillRect()` should use width and height (the original MS TS code had the same bug). i created a PR there, too.
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillRect